### PR TITLE
Adds simple sim PIDs so that mechanisms can gradually approach their targets

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -75,6 +75,8 @@ public class Constants {
 		public static final double FlywheelI = 0;
 		public static final double FlywheelD = 0;
 		public static final double FlywheelF = 0;
+
+		public static final double MaxRPM = 1000; // TODO: Change
 	}
 
 	public static class LiftConstants {

--- a/src/main/java/frc/robot/commands/Launch.java
+++ b/src/main/java/frc/robot/commands/Launch.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants.LauncherConstants;
 import frc.robot.Constants.LiftConstants;
 import frc.robot.subsystems.Feeder;
 import frc.robot.subsystems.Launcher;
@@ -34,8 +35,8 @@ public class Launch extends Command {
   public void execute() {
     m_feeder.setFeederPower(0.3);
     m_lift.moveToHeight(LiftConstants.DefaultLaunchMeters);
-    m_launcher.setLauncherPower(1.0);
-    m_launcher.setLauncherAngle(Rotation2d.fromDegrees(10));
+    m_launcher.setLauncherRPM(LauncherConstants.MaxRPM); // TODO: value should be determined from limelight/odometry
+    m_launcher.setLauncherAngle(Rotation2d.fromDegrees(10)); // TODO: value should be determined from limelight/odometry
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -2,7 +2,6 @@ package frc.robot.subsystems;
 
 import com.chaos131.pid.PIDFValue;
 import com.chaos131.pid.PIDTuner;
-import com.chaos131.pid.PIDValue;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.PositionVoltage;
@@ -10,17 +9,16 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
-import com.revrobotics.CANSparkBase.ControlType;
-import com.revrobotics.CANSparkFlex;
-import com.revrobotics.CANSparkLowLevel.MotorType;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
-import frc.robot.Robot;
 import frc.robot.Constants.CANIdentifiers;
 import frc.robot.Constants.IOPorts;
 import frc.robot.Constants.LiftConstants;
+import frc.robot.Robot;
 
 public class Lift extends SubsystemBase {
 	private DigitalInput m_bottomSensor = new DigitalInput(IOPorts.LiftBottomSensor);
@@ -31,7 +29,10 @@ public class Lift extends SubsystemBase {
 	private TalonFXConfiguration m_liftBConfig = new TalonFXConfiguration();
 	private PositionVoltage m_positionVoltage = new PositionVoltage(0);
 	
-	private double simHeight = LiftConstants.MinHeightMeters;
+	private double m_simHeight = LiftConstants.MinHeightMeters + 0.5; // Start off higher so we can see the lift move down
+	private double m_simPower = 0;
+	private double m_simMaxMetersChangePerLoop = 0.1;
+	private PIDController m_simPid = new PIDController(1, 0, 0);
 
 	private boolean m_hasSeenBottom = false;
 
@@ -54,6 +55,9 @@ public class Lift extends SubsystemBase {
 	}
 
 	public void setSpeed(double speed){
+		if (Robot.isSimulation()) {
+			m_simPower = speed;
+		}
 		m_liftA.set(speed);
 		m_liftB.set(speed);
 	}
@@ -74,7 +78,14 @@ public class Lift extends SubsystemBase {
 	 * @param heightMeters the height to move to
 	 */
 	public void moveToHeight(double heightMeters) {
-		simHeight = heightMeters;
+		if (!hasSeenBottom()) {
+			// If we haven't seen the bottom, don't allow Closed-loop control
+			return;
+		}
+
+		if (Robot.isSimulation()) {
+			m_simPower = MathUtil.clamp(m_simPid.calculate(m_simHeight, heightMeters), -1.0, 1.0);
+		}
 		m_positionVoltage.Slot = 0;
 		m_liftA.setControl(m_positionVoltage.withPosition(heightMeters));
 		m_liftB.setControl(m_positionVoltage.withPosition(heightMeters));
@@ -85,12 +96,15 @@ public class Lift extends SubsystemBase {
 	 */
 	public double getCurrentHeightMeters() {
 		if (Robot.isSimulation()) {
-			return simHeight;
+			return m_simHeight;
 		}
 		return m_liftA.getPosition().getValueAsDouble();
 	}
 
 	public boolean atBottom() {
+		if (Robot.isSimulation()) {
+			return m_simHeight < LiftConstants.MinHeightMeters;
+		}
 		return m_bottomSensor.get();
 	}
 	
@@ -102,10 +116,14 @@ public class Lift extends SubsystemBase {
 	public void periodic() {
 		super.periodic();
 		m_liftPidTuner.tune();
-		if(atBottom() && !hasSeenBottom()){
+		if (atBottom() && !hasSeenBottom()){
 			m_hasSeenBottom = true;
 			m_liftA.setPosition(LiftConstants.MinHeightMeters);
 			m_liftB.setPosition(LiftConstants.MinHeightMeters);
+		}
+
+		if (Robot.isSimulation()) {
+			m_simHeight += m_simPower * m_simMaxMetersChangePerLoop;
 		}
 	}
 }

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -79,6 +79,7 @@ public class Lift extends SubsystemBase {
 	 */
 	public void moveToHeight(double heightMeters) {
 		if (!hasSeenBottom()) {
+			m_simPower = 0;
 			// If we haven't seen the bottom, don't allow Closed-loop control
 			return;
 		}


### PR DESCRIPTION
This adds some controls so that we can have the lift, launcher angle, and launcher flywheels approach their targets slowly - this forces the robot sim to spend some time approaching set points.

This will enable us to test and view in the CHAOSBoard certain logic, such as:
- While launching, don't run the feeder until lift, flywheels, and launcher angle are at their targets
- Don't let the lift run in closed-loop mode until the lift has seen the bottom sensor
  - I added a quick check to the code to enforce this, but we will probably want something better/safer.
- Don't drop a piece in the amp until the lift and angle are achieved


https://github.com/Manchester-Central/2024-Crescendo/assets/6991773/14ffdb15-9d47-4482-936a-3c3ea1953f68

