### PR TITLE
Adds Pigeon Gyro

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -19,7 +19,7 @@ public class Constants {
 	public static final double robotLengthMeters = 0.9779;
 
 	public static class DebugConstants {
-		public static final boolean DriveDebugEnable = false;
+		public static final boolean DriveDebugEnable = true;
 		public static final boolean IntakeDebugEnable = false;
 		public static final boolean FeederDebugEnable = false;
 		public static final boolean LiftDebugEnable = false;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -19,7 +19,7 @@ public class Constants {
 	public static final double robotLengthMeters = 0.9779;
 
 	public static class DebugConstants {
-		public static final boolean DriveDebugEnable = true;
+		public static final boolean DriveDebugEnable = false;
 		public static final boolean IntakeDebugEnable = false;
 		public static final boolean FeederDebugEnable = false;
 		public static final boolean LiftDebugEnable = false;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -97,6 +97,8 @@ public class Constants {
 		public static final int FeederTrap = 50;
 
 		public static final int TiltCANCoder = 51;
+
+		public static final int PigeonGyro = 52;
 	}
 
 	public static class IOPorts {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -124,7 +124,7 @@ public class RobotContainer {
 
 
   public RobotContainer() {
-    m_PDH.setSwitchableChannel(false);
+    m_PDH.setSwitchableChannel(true);
     m_swerveDrive.resetPose(FieldPose2024.TestStart.getCurrentAlliancePose());
     configureBindings();
 

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveDrive2024.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveDrive2024.java
@@ -8,22 +8,25 @@ import com.chaos131.swerve.implementation.TalonFxAndCancoderSwerveModule.Absolut
 import com.chaos131.swerve.implementation.TalonFxAndCancoderSwerveModule.AngleControllerConfig;
 import com.chaos131.swerve.implementation.TalonFxAndCancoderSwerveModule.DriveConfig;
 import com.chaos131.swerve.implementation.TalonFxAndCancoderSwerveModule.SpeedControllerConfig;
+import com.ctre.phoenix6.configs.Pigeon2Configuration;
+import com.ctre.phoenix6.hardware.Pigeon2;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
-import com.kauailabs.navx.frc.AHRS;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.wpilibj.SPI;
 import frc.robot.Constants;
 import frc.robot.Constants.CANIdentifiers;
 import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.SwerveConstants2024;
 
 public class SwerveDrive2024 extends SwerveDrive {
-	private SwerveDrive2024(BaseSwerveModule[] modules, SwerveConfigs configs, Supplier<Rotation2d> getRotation) {
+	private Pigeon2 m_gyro;
 
-		super(modules, configs, getRotation);
+	private SwerveDrive2024(BaseSwerveModule[] modules, SwerveConfigs configs, Pigeon2 gyro) {
+
+		super(modules, configs, () -> gyro.getRotation2d());
+		m_gyro = gyro;
 	}
 
 	public static SwerveDrive2024 createSwerveDrive() {
@@ -98,9 +101,9 @@ public class SwerveDrive2024 extends SwerveDrive {
 		);
 
 		BaseSwerveModule[] modules = { frontLeftModule, frontRightModule, backLeftModule, backRightModule };
-		var gyro = new AHRS(SPI.Port.kMXP);
+		var gyro = new Pigeon2(CANIdentifiers.PigeonGyro);
 
-		return new SwerveDrive2024(modules, configs, () -> gyro.getRotation2d());
+		return new SwerveDrive2024(modules, configs, gyro);
 	}
 
 	// public void testModuleSpeed(double percentSpeed) {


### PR DESCRIPTION
Preps for replacing the NavX with a Pigeon 2.0 as the gyro for the bot.

The Nav-X is restarting when the rio brownsout, since the Rio disables power to the MXP connection when it occurs